### PR TITLE
Fixing AppSeer without Seer bug

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Helpers/UpdateHelper.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/UpdateHelper.cs
@@ -12,11 +12,9 @@ namespace Werewolf_Control.Helpers
     {
         internal static int[] Devs =
         {
-            129046388,  //Para
-            133748469,  //reny
-            125311351,  //Daniel
-            295152997,  //Ludwig
+            458347115,  //Thestor Bot Manager 👮
             173887991,  //rainzy
+            86147536,   //❄️ 🐺 SKÖLL 🐺 ❄️
         };
         internal static bool IsGroupAdmin(Update update)
         {

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1343,8 +1343,6 @@ namespace Werewolf_Node
                     rolesToAssign.Shuffle();
                     rolesToAssign = rolesToAssign.Take(count).ToList();
 
-
-
                     //let's fix some roles that should or shouldn't be there...
 
                     //sorcerer or traitor, without wolves, are pointless. change one of them to wolf
@@ -1355,14 +1353,6 @@ namespace Werewolf_Node
                         rolesToAssign[towolf] = WolfRoles[Program.R.Next(3)]; //choose randomly from WolfRoles
                     }
 
-                    //appseer without seer -> seer
-                    if (rolesToAssign.Contains(IRole.ApprenticeSeer) && !rolesToAssign.Contains(IRole.Seer))
-                    {
-                        //substitute with seer
-                        var apps = rolesToAssign.IndexOf(IRole.ApprenticeSeer);
-                        rolesToAssign[apps] = IRole.Seer;
-                    }
-
                     //cult without CH -> add CH
                     if (rolesToAssign.Contains(IRole.Cultist) && !rolesToAssign.Contains(IRole.CultistHunter))
                     {
@@ -1371,6 +1361,13 @@ namespace Werewolf_Node
                         rolesToAssign[vg] = IRole.CultistHunter;
                     }
 
+                    //appseer without seer -> seer
+                    if (rolesToAssign.Contains(IRole.ApprenticeSeer) && !rolesToAssign.Contains(IRole.Seer))
+                    {
+                        //substitute with seer
+                        var apps = rolesToAssign.IndexOf(IRole.ApprenticeSeer);
+                        rolesToAssign[apps] = IRole.Seer;
+                    }
 
                     //make sure that we have at least two teams
                     if (


### PR DESCRIPTION
The balancing of the rolelist first checked if there was seer when there was appseer, then checked if there was cultist hunter when there is cult. This last step would remove a village role to make room for cultist hunter, so seer could be removed. I fixed the bug by just changing the order. It now checks for CH first, then for seer, to make sure the game never starts with AppSeer without Seer.